### PR TITLE
Update to guzzle 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 before_install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ print_r($client->languages());
 | Version | Status     | Repo                 | PHP Version   |
 |---------|------------|----------------------|---------------|
 | 2.*     | Maintained |  [v2][client-2-repo] | >= 5.6 <= 7.1 |
-| 3.x     | Latest     |  [v3][client-3-repo] | >= 7.2        |
+| 3.*     | Latest     |  [v3][client-3-repo] | >= 7.2        |
 
 [client-2-repo]: https://github.com/viniciusgava/google-translate-php-client/tree/2.1
 [client-3-repo]: https://github.com/viniciusgava/google-translate-php-client

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "~6.3.0",
+        "guzzlehttp/guzzle": "^7.0.1",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
# Changes
- Add PHP 8 to CI
- **Change from Guzzle 6 to 7**
- fix typo documentation.

# Breaking changes
- Since we are updating to **guzzle 7**, it may cause incompatibility with other libraries using guzzle in a different version.

# Related issues
- https://github.com/viniciusgava/google-translate-php-client/issues/14